### PR TITLE
Handle adding and removing relations from Roles.

### DIFF
--- a/parse_rest/role.py
+++ b/parse_rest/role.py
@@ -30,6 +30,28 @@ class Role(ParseResource):
 
     def __repr__(self):
         return '<Role:%s (Id %s)>' % (getattr(self, 'name', None), self.objectId)
+    
+    def removeRelation(self, key, className, objectsId):
+        self.manageRelation('RemoveRelation', key, className, objectsId)
+
+    def addRelation(self, key, className, objectsId):
+        self.manageRelation('AddRelation', key, className, objectsId)
+
+    def manageRelation(self, action, key, className, objectsId):
+        objects = [{
+                    "__type": "Pointer",
+                    "className": className,
+                    "objectId": objectId
+                    } for objectId in objectsId]
+
+        payload = {
+            key: {
+                 "__op": action,
+                 "objects": objects
+                }
+            }
+        self.__class__.PUT(self._absolute_url, **payload)
+        self.__dict__[key] = ''
 
 
 Role.Query = QueryManager(Role)


### PR DESCRIPTION
This adds addRelation and removeRelation capabilities to Role, making it possible to add users to the users column and roles to the roles column in a Role object, for example. This prevents the error of Role not having the attribute addRelation or removeRelation when trying to add users or roles to a Role, which is critical for Role functionality.